### PR TITLE
updated trunk workflow to 0.5.0

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
       - name: Install Trunk
-        uses: jetli/trunk-action@v0.4.0
+        uses: jetli/trunk-action@v0.5.0
         with:
           # Optional version of trunk to install(eg. 'v0.16.0', 'latest')
           version: "latest"


### PR DESCRIPTION
I've been tinkering with a fork of your nice repo and build a minimal table example.

while doing so I noticed the [trunk action](https://github.com/jetli/trunk-action) being used raises a warning so I bumped it up to the latest version and the warning went away.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: jetli/trunk-action@v0.4.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```